### PR TITLE
Add activation event for .nmap files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onLanguage:nmap-oN"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "languages": [


### PR DESCRIPTION
## Summary
- activate extension when opening `nmap-oN` files

## Testing
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5cd7cc883238f83444678ed090a