### PR TITLE
Fix symbol provider host checks

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,19 +29,21 @@ class NmapNormalOutputSymbolProvider implements vscode.DocumentSymbolProvider {
                     'Aggressive OS Guess', '',
                     vscode.SymbolKind.Module,
                     line.range, line.range);
-                    
-                    guesses.forEach((guess) => {
-                        const symbol = new vscode.DocumentSymbol(
+
+                guesses.forEach((guess) => {
+                    const symbol = new vscode.DocumentSymbol(
                         guess, 'OS Guess',
                         vscode.SymbolKind.Object,
                         line.range, line.range);
-                        parent_symbol.children.push(symbol);
-                    });
+                    parent_symbol.children.push(symbol);
+                });
 
+                if (chunk.length > 0) {
                     chunk[chunk.length - 1].children.push(parent_symbol);
-                } else if (this.openPortRegex.test(line.text)) {
+                }
+            } else if (this.openPortRegex.test(line.text)) {
                 const match = line.text.match(this.openPortRegex);
-                if (!match) {
+                if (!match || chunk.length === 0) {
                     continue;
                 }
 
@@ -60,9 +62,11 @@ class NmapNormalOutputSymbolProvider implements vscode.DocumentSymbolProvider {
 
                 let symbol = new vscode.DocumentSymbol(
                     String(match[1]), match[4],
-                    symbolkind, 
+                    symbolkind,
                     line.range, line.range);
-                chunk[chunk.length - 1].children.push(symbol);
+                if (chunk.length > 0) {
+                    chunk[chunk.length - 1].children.push(symbol);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- prevent pushing child symbols when no host has been found

## Testing
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_683fa61150688323ae5c48095c37d95a